### PR TITLE
Modify service=drive-through to service=drive_through

### DIFF
--- a/resources/map_features/roads.xml
+++ b/resources/map_features/roads.xml
@@ -201,7 +201,7 @@
       <choice value="alley" text="Alleyway/laneway"/>
       <choice value="parking_aisle" text="Parking aisle" description="The path that cars drive on through a parking lot."/>
       <choice value="driveway" text="Driveway"/>
-      <choice value="drive-through" text="Drive-through" description="For drive-through restaurants, bottle shops etc."/>
+      <choice value="drive_through" text="Drive-through" description="For drive-through restaurants, bottle shops etc."/>
       <choice value="emergency_access" text="Emergency access" description="For firefighters and other emergency services."/>
     </input>
     <inputSet ref="common"/>


### PR DESCRIPTION
Modify service=drive-through to service=drive_through based on tagging mailing list discussion (Oct 2010) http://www.mail-archive.com/tagging@openstreetmap.org/msg05167.html and updated Wiki page description (Apr 2011) http://wiki.openstreetmap.org/wiki/Tag:service%3Ddrive_through.
