### PR TITLE
Fix for stack overflow when tabbing in simple editor

### DIFF
--- a/net/systemeD/halcyon/connection/actions/SetTagAction.as
+++ b/net/systemeD/halcyon/connection/actions/SetTagAction.as
@@ -17,7 +17,8 @@ package net.systemeD.halcyon.connection.actions {
         public override function doAction():uint {
             var tags:Object = entity.getTagsHash();
             oldValue = tags[key];
-            if ( value == null || key == '' || oldValue != value ) {
+            if ( !( ( entity.getTag(key) == null ) && ( value == null && oldValue == null ) ) &&
+                ( value == null || key == '' || oldValue != value ) ) {
                 if ( value == null || key == '' || value == '' )
                     delete tags[key];
                 else


### PR DESCRIPTION
Selecting and deselecting an empty input field in simple editor shouldn't trig TAG_CHANGED as it may trigger an infinite loop.

Not a fix for the various focus issues in the simple editor, but at least it gets rid of the crashes.

Fixes stack overflow when:
1. Opening P2
2. Double clicking in map to create node
3. Choosing a pre-set from the CategorySelector (i.e. Bus stop)
4. Choosing tab "Naptan"
5. Setting focus to "Naptan common name" and pressing TAB.
