### PR TITLE
Fix #4114

### DIFF
--- a/net/systemeD/halcyon/styleparser/RuleSet.as
+++ b/net/systemeD/halcyon/styleparser/RuleSet.as
@@ -531,7 +531,7 @@ package net.systemeD.halcyon.styleparser {
 
         public static function parseCSSColor(colorStr:String):uint {
             colorStr = colorStr.toLowerCase();
-            if (CSSCOLORS[colorStr]) {
+            if (CSSCOLORS[colorStr] != undefined) {
                 return CSSCOLORS[colorStr];
             } else {
                 var match:Object = HEX.exec(colorStr);

--- a/net/systemeD/halcyon/styleparser/Style.as
+++ b/net/systemeD/halcyon/styleparser/Style.as
@@ -56,7 +56,7 @@ package net.systemeD.halcyon.styleparser {
 		public function mergeWith(additional:Style):void {
 			for each (var prop:String in properties) {
 				// Note extra check for empty arrays, which we use to mean 'undefined' (see setPropertyFromString below)
-				if (additional[prop] && !((additional[prop] is Array) && additional[prop].length==0)) {
+				if (additional[prop] != undefined && !((additional[prop] is Array) && additional[prop].length==0)) {
 					this[prop]=additional[prop];
 				}
 			}


### PR DESCRIPTION
Note: this kind of code can be a bug:
if (CSSCOLORS[colorstr]) {  }

do this instead:
if (CSSCOLORS[colorstr] != undefined) {  }
