### PR TITLE
Rework handling of choice editor images

### DIFF
--- a/net/systemeD/potlatch2/mapfeatures/editors/Choice.as
+++ b/net/systemeD/potlatch2/mapfeatures/editors/Choice.as
@@ -2,6 +2,7 @@ package net.systemeD.potlatch2.mapfeatures.editors {
 
     import flash.events.*;
     import flash.utils.ByteArray;
+    import net.systemeD.halcyon.FileBank;
 
 	public class Choice extends EventDispatcher {
 
@@ -27,8 +28,10 @@ package net.systemeD.potlatch2.mapfeatures.editors {
                 _match = new RegExp("^("+matchStr+")$");
             }
         }
+
+        public function imageLoaded(fileBank:FileBank, name:String):void {
+            icon = fileBank.getAsByteArray(name);
+            dispatchEvent(new Event("iconLoaded"));
+        }        
     }
-
 }
-
-

--- a/net/systemeD/potlatch2/mapfeatures/editors/ChoiceEditorFactory.as
+++ b/net/systemeD/potlatch2/mapfeatures/editors/ChoiceEditorFactory.as
@@ -24,10 +24,7 @@ package net.systemeD.potlatch2.mapfeatures.editors {
                 choice.match = String(choiceXML.@match);
                 if (choiceXML.hasOwnProperty("@icon")) {
                     var icon:String = String(choiceXML.@icon);
-                    fileBank.addFromFile(icon, function (fb:FileBank, name:String):void {
-                        choice.icon = fb.getAsByteArray(name);
-                        choice.dispatchEvent(new Event("iconLoaded"));
-                    });
+                    fileBank.addFromFile(icon, choice.imageLoaded);
                 }
                 choices.push(choice);
             }


### PR DESCRIPTION
I have no idea why this approach works better, but it seems to lead to more reliable loading of the images and is closer to the way the original pre-FileBank code worked.
