### PR TITLE
Allow speedier build options

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -59,6 +59,13 @@ You can create and run the unit tests (not that there are that many) using flexu
 
 * ant test
 
+For those that don't need I8n, the following give a much speedier build as it skips the all the language translation build steps.
+As an extra bonus, this uses much less memory and you may get away without needing to tell ant to use more memory (see below).
+
+* ant debug-no-locales
+or
+* ant release-no-locales
+
 If you're using Mac OS X, you may need to tell ant to use more memory, by
 typing export ANT_OPTS="-Xms768m -Xmx1024m -XX:MaxPermSize=512m" 
 beforehand (you can put this in your .profile).

--- a/build.xml
+++ b/build.xml
@@ -31,10 +31,16 @@
   </target>
 
   <!-- delete and create the DEPLOY dir again -->
-  <target name="init" depends="git-buildnumber,svn-buildnumber,deployLocales">
+  <target name="build-number" depends="git-buildnumber,svn-buildnumber">
     <echo>Build Number ${build_number}</echo>
     <copy file="version.as.template" tofile="version.as" overwrite="true" />
     <replace file="version.as" token="@@@buildnumber@@@" value="${build_number}" />
+  </target>
+
+  <target name="init" depends="build-number, deployLocales">
+  </target>
+
+  <target name="init-no-locales" depends="build-number">
   </target>
 
   <!-- Build and output potlatch2.swf in debug mode -->
@@ -47,8 +53,25 @@
     </mxmlc>
   </target>
 
+  <target name="debug-no-locales" depends="init-no-locales">
+    <mxmlc file="potlatch2.mxml">
+      <load-config filename="${FLEX_HOME}/frameworks/flex-config.xml"/>
+      <load-config filename="debug-config.xml"/>
+      <source-path path-element="${FLEX_HOME}/frameworks"/>
+      <compiler.debug>true</compiler.debug>
+    </mxmlc>
+  </target>
+
   <!-- Build and output potlatch2.swf in release mode -->
   <target name="release" depends="init"> <!-- FIXME convention is dist not release -->
+    <mxmlc file="potlatch2.mxml">
+      <load-config filename="${FLEX_HOME}/frameworks/flex-config.xml"/>
+      <source-path path-element="${FLEX_HOME}/frameworks"/>
+      <compiler.debug>false</compiler.debug>
+    </mxmlc>
+  </target>
+
+  <target name="release-no-locales" depends="init-no-locales"> <!-- FIXME convention is dist not release -->
     <mxmlc file="potlatch2.mxml">
       <load-config filename="${FLEX_HOME}/frameworks/flex-config.xml"/>
       <source-path path-element="${FLEX_HOME}/frameworks"/>


### PR DESCRIPTION
Allow speedier build options by adding 'debug-no-locales' and 'release-no-locales' to build without i8n.

Rework the build file slighty to allow commonization and document usage in the README.txt
