### PR TITLE
Fixed MapQuest Open Aerial URL

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -14,7 +14,7 @@
 	</set>
     <set>
         <name>MapQuest Open Aerial</name>
-        <url>http://oatile1.mqcdn.com/naip/$z/$x/$y.png</url>
+        <url>http://oatile1.mqcdn.com/tiles/1.0.0/sat/$z/$x/$y.jpg</url>
     </set>
 	<set>
 		<name>OSM - Mapnik</name>
@@ -30,7 +30,7 @@
     </set>
     <set>
         <name>OSM - MapQuest</name>
-        <url>http://otile1.mqcdn.com/tiles/1.0.0/osm/$z/$x/$y.png</url>
+        <url>http://otile1.mqcdn.com/tiles/1.0.0/osm/$z/$x/$y.jpg</url>
     </set>
     <set minlat="17" minlon="175" maxlat="72" maxlon="-46">
       <name>OSM - Tiger Edited Map</name>


### PR DESCRIPTION
Fixed MapQuest Open Aerial layer to use the URL instead of the deprecated one. Also, MapQuest tiles are JPEGs, not PNGs.
