### PR TITLE
imagery.xml changes

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -3,10 +3,10 @@
 <imagery>
 	<set>
 		<name>Bing aerial imagery</name>
-		<url>http://ecn.t0.tiles.virtualearth.net/tiles/a$quadkey.jpeg?g=587&mkt=en-gb&n=z</url>
+		<url>http://ecn.t0.tiles.virtualearth.net/tiles/a$quadkey.jpeg?g=587&amp;mkt=en-gb&amp;n=z</url>
 		<scheme>microsoft</scheme>
 		<sourcetag>Bing</sourcetag>
-		<attribution_url>http://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial/0,0?zl=1&mapVersion=v1&key=Arzdiw4nlOJzRwOz__qailc8NiR31Tt51dN2D7cm57NrnceZnCpgOkmJhNpGoppU&include=ImageryProviders&output=xml</attribution_url>
+		<attribution_url>http://dev.virtualearth.net/REST/v1/Imagery/Metadata/Aerial/0,0?zl=1&amp;mapVersion=v1&amp;key=Arzdiw4nlOJzRwOz__qailc8NiR31Tt51dN2D7cm57NrnceZnCpgOkmJhNpGoppU&amp;include=ImageryProviders&amp;output=xml</attribution_url>
 		<logo>bing_maps.png</logo>
 		<logo_url>http://www.bing.com/maps</logo_url>
 		<terms_url>http://opengeodata.org/microsoft-imagery-details</terms_url>
@@ -162,12 +162,12 @@
 	</set>
 	<set minlon="19.02" minlat="40.96" maxlon="77.34" maxlat="70.48">
 		<name>Russia - Kosmosnimki.ru IRS Satellite</name>
-		<url>http://irs.gis-lab.info/?layers=irs&request=GetTile&z=$z&x=$x&y=$y</url>
+		<url>http://irs.gis-lab.info/?layers=irs&amp;request=GetTile&amp;z=$z&amp;x=$x&amp;y=$y</url>
 		<sourcetag>Kosmosnimki.ru IRS</sourcetag>
 	</set>
 	<set minlon="23.16" minlat="51.25" maxlon="32.83" maxlat="56.19">
 		<name>Belarus - Kosmosnimki.ru SPOT4 Satellite</name>
-		<url>http://irs.gis-lab.info/?layers=spot&request=GetTile&z=$z&x=$x&y=$y</url>
+		<url>http://irs.gis-lab.info/?layers=spot&amp;request=GetTile&amp;z=$z&amp;x=$x&amp;y=$y</url>
 		<sourcetag>Kosmosnimki.ru SPOT4</sourcetag>
 	</set>
 	<set minlon="96" minlat="-44" maxlon="168" maxlat="-9">


### PR DESCRIPTION
These patches refine the OS bounds slightly based on the 2012 data now up, add a new bc-specific and uses proper entities in the XML
