### PR TITLE
More imagery bounds

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -82,7 +82,7 @@
       <name>British Columbia bc_mosaic</name>
       <type>900913</type>
       <url>http://${a|b|c|d}.imagery.paulnorman.ca/tiles/bc_mosaic/$z/$x/$y.png</url>
-      <attribution_url>http://imagery.paulnorman.ca/tiles/about.html</attribution_url>
+      <terms_url>http://imagery.paulnorman.ca/tiles/about.html</terms_url>
       <sourcetag>bc_mosaic</sourcetag>
     </set>
 	<set minlat="49.86" minlon="-8.72" maxlat="60.92" maxlon="1.84">


### PR DESCRIPTION
This pull request splits US imagery into alaska, hawaii and CONUS and fixes some bc_mosaic errors.
