### PR TITLE
Implement the ant clean task.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -332,15 +332,11 @@
 
   <target name="clean"
     description="clean up" >
-    <!-- Delete the ${build} and ${dist} directory trees -->
-    <!--
-
-    FIXME what is supposed to be cleaned?
-
-    <delete dir="${build}"/>
-    <delete dir="${dist}"/>
-
-    -->
+    <delete dir="${basedir}/resources/generated"/>
+    <delete dir="${basedir}/resources/locales"/>
+    <delete>
+      <fileset dir="${basedir}/resources" includes="potlatch2.swf*"/>
+    </delete>
   </target>
 
 


### PR DESCRIPTION
This way you can get rid of any generated files which may be causing issues (as they were for me) using the standard ant command, even when a new build wasn't working due to some corruption.
