### PR TITLE
Make the building type selector more prominent.

### DIFF
--- a/resources/map_features.xml
+++ b/resources/map_features.xml
@@ -561,7 +561,7 @@
   </inputSet>
 
   <inputSet id="isBuilding">
-    <input type="choice" presence="withCategory" category="Details" name="Building type, if it is one" key="building">
+    <input type="choice" presence="always" category="Details" name="Building type, if it is one" key="building">
       <choice value="yes" text="Generic building"/>
       <choice value="residential" text="Generic residential"/>
       <choice value="apartments" text="Big apartments house"/>


### PR DESCRIPTION
There are too many building=yes in OSM, and very few that specify thetype, which is probably due to this menu being hidden in a tab, so lets expose it on the basic tab.
