### PR TITLE
Updated TIGER road names tiles URL

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -44,19 +44,19 @@
       <url>http://tiger-osm.mapquest.com/tiles/1.0.0/tiger/$z/$x/$y.png</url>
     </set>
     <set minlat="24.055" minlon="-124.810" maxlat="49.386" maxlon="-66.865">
-      <name>OSM US TIGER 2011 Roads Overlay</name>
+      <name>OSM US TIGER 2012 Roads Overlay</name>
       <type>900913</type>
-      <url>http://${a|b|c}.tile.openstreetmap.us/tiger2011_roads/$z/$x/$y.png</url>
+      <url>http://${a|b|c}.tile.openstreetmap.us/tiger2012_roads_expanded/$z/$x/$y.png</url>
     </set>
     <set minlat="50.858" minlon="-179.754" maxlat="71.463" maxlon="-129.899">
-      <name>OSM US TIGER 2011 Roads Overlay</name>
+      <name>OSM US TIGER 2012 Roads Overlay</name>
       <type>900913</type>
-      <url>http://${a|b|c}.tile.openstreetmap.us/tiger2011_roads/$z/$x/$y.png</url>
+      <url>http://${a|b|c}.tile.openstreetmap.us/tiger2012_roads_expanded/$z/$x/$y.png</url>
     </set>
     <set minlat="18.702" minlon="-174.460" maxlat="26.501" maxlon="-154.516">
-      <name>OSM US TIGER 2011 Roads Overlay</name>
+      <name>OSM US TIGER 2012 Roads Overlay</name>
       <type>900913</type>
-      <url>http://${a|b|c}.tile.openstreetmap.us/tiger2011_roads/$z/$x/$y.png</url>
+      <url>http://${a|b|c}.tile.openstreetmap.us/tiger2012_roads_expanded/$z/$x/$y.png</url>
     </set>
     <set minlat="24.005" minlon="-125.991" maxlat="50.009" maxlon="-65.988">
       <name>OSM US USGS Topographic Maps</name>


### PR DESCRIPTION
Update to the imagery URLs to point at the newest 2012 TIGER road names tiles being served up by OSM-US.
