### PR TITLE
Discard useless import tags from modified objects

### DIFF
--- a/net/systemeD/halcyon/connection/XMLConnection.as
+++ b/net/systemeD/halcyon/connection/XMLConnection.as
@@ -21,6 +21,12 @@ package net.systemeD.halcyon.connection {
 	public class XMLConnection extends XMLBaseConnection {
 
 		private const MARGIN:Number=0.05;
+		private var discardTags:Array=["created_by",
+			"tiger:upload_uuid", "tiger:tlid", "tiger:source", "tiger:separated",
+			"geobase:datasetName", "geobase:uuid", "sub_sea:type",
+			"odbl", "odbl:note",
+			"yh:LINE_NAME", "yh:LINE_NUM", "yh:STRUCTURE", "yh:TOTYUMONO",
+			"yh:TYPE", "yh:WIDTH_RANK"];
 
         /**
         * Create a new XML connection
@@ -453,8 +459,8 @@ package net.systemeD.halcyon.connection {
             xml.@id = entity.id;
             xml.@version = entity.version;
             for each( var tag:Tag in entity.getTagArray() ) {
-              if (tag.key == 'created_by') {
-                entity.setTag('created_by', null, MainUndoStack.getGlobalStack().addAction);
+              if (discardTags.indexOf(tag.key) > -1) {
+                entity.setTag(tag.key, null, MainUndoStack.getGlobalStack().addAction);
                 continue;
               }
               var tagXML:XML = <tag/>


### PR DESCRIPTION
There are tags that were added by some imports that are useless bloat. After discussing with the respective communities it was decided to add these tags to an automatic discard list in editors, like what was done with the created_by tag. JOSM implemented this a little while ago. This adds similar functionality to P2.

This addresses a ticket I submitted in trac:
https://trac.openstreetmap.org/ticket/4552

Disclaimer: 
2 hours ago was the first time I had ever laid eyes on ActionScript. I tested this change against the dev API and it seems to work as advertised.
