### PR TITLE
Add MapBox imagery

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -12,6 +12,10 @@
     <default>yes</default>
   </set>
   <set>
+    <name>MapBox Satellite</name>
+    <url>https://tiles.mapbox.com/v3/openstreetmap.map-4wvf9l0l/$z/$x/$y.png</url>
+  </set>
+  <set>
     <name>MapQuest Open Aerial</name>
     <url>http://oatile1.mqcdn.com/tiles/1.0.0/sat/$z/$x/$y.jpg</url>
   </set>


### PR DESCRIPTION
- Adds a "MapBox Satellite" entry in imagery menu.
- Straightforward change, but not tested on app.
- Depends on #94
