### PR TITLE
Cyclestreets snapshot-server layers

### DIFF
--- a/resources/vectors.xml
+++ b/resources/vectors.xml
@@ -29,4 +29,730 @@
     <policyfile>http://localhost:3000/crossdomain.xml</policyfile>
     <url>http://localhost:3000/api/</url>
   </set>
+  <set minlat="52.125986" minlon="0.036189" maxlat="52.257591" maxlon="0.211712">
+    <name>Cambridge - 20111220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/1/api/</url>
+  </set>
+  <set minlat="51.275516" minlon="-2.99024" maxlat="51.655351" maxlon="-2.255386">
+    <name>CUBA - 20111222</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/2/api/</url>
+  </set>
+  <set minlat="50.221073" minlon="-4.372911" maxlat="51.229552" maxlon="-2.97209">
+    <name>Devon-20120116</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/3/api/</url>
+  </set>
+  <set minlat="51.115342" minlon="-2.756234" maxlat="51.287754" maxlon="-2.317007">
+    <name>Mendip-20120105</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/4/api/</url>
+  </set>
+  <set minlat="52.891787" minlon="-1.276359" maxlat="53.021062" maxlon="-1.060084">
+    <name>Nottingham - 20120105</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/5/api/</url>
+  </set>
+  <set minlat="50.86804" minlon="-2.97167" maxlat="51.101364" maxlon="-2.405676">
+    <name>SouthSomerset - 20120109.osm</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/6/api/</url>
+  </set>
+  <set minlat="50.94047" minlon="-3.261668" maxlat="51.287922" maxlon="-2.756437">
+    <name>TauntonSedgemoor - 20120103.osm</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/7/api/</url>
+  </set>
+  <set minlat="53.446118" minlon="-1.794391" maxlat="53.590712" maxlon="-1.282918">
+    <name>Barnsley - 20120126</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/8/api/</url>
+  </set>
+  <set minlat="52.140648" minlon="-0.486037" maxlat="52.170628" maxlon="-0.324354">
+    <name>Bedford - 20120222</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/9/api/</url>
+  </set>
+  <set minlat="52.383446" minlon="-2.034545" maxlat="52.606734" maxlon="-1.735104">
+    <name> Birmingham - 20120126</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/10/api/</url>
+  </set>
+  <set minlat="53.760933" minlon="-1.997005" maxlat="53.944941" maxlon="-1.720317">
+    <name>Bradford - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/11/api/</url>
+  </set>
+  <set minlat="53.677657" minlon="-2.104245" maxlat="53.755482" maxlon="-1.920416">
+    <name>Calderdale - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/12/api/</url>
+  </set>
+  <set minlat="51.454425" minlon="-0.291607" maxlat="51.551658" maxlon="0.01889">
+    <name>CentralLondon - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/13/api/</url>
+  </set>
+  <set minlat="54.798062" minlon="-1.846782" maxlat="54.924351" maxlon="-1.324143">
+    <name>County Durham - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/14/api/</url>
+  </set>
+  <set minlat="52.373939" minlon="-1.593274" maxlat="52.459229" maxlon="-1.43839">
+    <name>Coventry - 20120126</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/15/api/</url>
+  </set>
+  <set minlat="53.47027" minlon="-1.278989" maxlat="53.648722" maxlon="-0.951668">
+    <name>Doncaster - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/16/api/</url>
+  </set>
+  <set minlat="52.42796" minlon="-2.177923" maxlat="52.543983" maxlon="-2.038285">
+    <name>Dudley - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/17/api/</url>
+  </set>
+  <set minlat="54.914545" minlon="-1.81668" maxlat="54.984752" maxlon="-1.532404">
+    <name>Gateshead - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/18/api/</url>
+  </set>
+  <set minlat="53.593145" minlon="-1.929925" maxlat="53.761882" maxlon="-1.599262">
+    <name>Kirklees - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/19/api/</url>
+  </set>
+  <set minlat="53.724236" minlon="-1.762176" maxlat="53.951616" maxlon="-1.324629">
+    <name>Leeds - 20120124</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/20/api/</url>
+  </set>
+  <set minlat="51.849335" minlon="-0.600175" maxlat="52.146263" maxlon="-0.233692">
+    <name>Luton - 20120222</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/21/api/</url>
+  </set>
+  <set minlat="53.344588" minlon="-2.617177" maxlat="53.680782" maxlon="-1.979456">
+    <name>Manchester - 20120222</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/22/api/</url>
+  </set>
+  <set minlat="53.302379" minlon="-3.183551" maxlat="53.676653" maxlon="-2.599684">
+    <name>Merseyside - 20120222</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/23/api/</url>
+  </set>
+  <set minlat="51.983152" minlon="-0.837634" maxlat="52.084268" maxlon="-0.668895">
+    <name>MiltonKeynes - 20120222</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/24/api/</url>
+  </set>
+  <set minlat="54.983124" minlon="-1.639232" maxlat="55.079658" maxlon="-1.41816">
+    <name>NorthTyneside - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/25/api/</url>
+  </set>
+  <set minlat="54.965754" minlon="-1.866967" maxlat="55.257402" maxlon="-1.462074">
+    <name>Northumberland - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/26/api/</url>
+  </set>
+  <set minlat="50.777121" minlon="-1.268316" maxlat="50.913139" maxlon="-0.937667">
+    <name>Portsmouth - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/27/api/</url>
+  </set>
+  <set minlat="53.327417" minlon="-1.323335" maxlat="53.516332" maxlon="-1.165985">
+    <name>Rotherham - 20120126</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/28/api/</url>
+  </set>
+  <set minlat="54.487903" minlon="-2.118336" maxlat="54.839559" maxlon="-1.303465">
+    <name>Rural County Durham - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/29/api/</url>
+  </set>
+  <set minlat="54.8575" minlon="-2.588127" maxlat="55.77881" maxlon="-1.550149">
+    <name>Rural Northumberland - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/30/api/</url>
+  </set>
+  <set minlat="52.464708" minlon="-2.094604" maxlat="52.565524" maxlon="-2.02934">
+    <name>Sandwell - 20120126</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/31/api/</url>
+  </set>
+  <set minlat="52.348046" minlon="-1.834044" maxlat="52.515066" maxlon="-1.620207">
+    <name>Solihull - 20120126</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/32/api/</url>
+  </set>
+  <set minlat="50.850552" minlon="-1.471079" maxlat="50.999357" maxlon="-1.26796">
+    <name>Southampton - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/33/api/</url>
+  </set>
+  <set minlat="54.944498" minlon="-1.537437" maxlat="55.005285" maxlon="-1.356727">
+    <name>SouthTyneside - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/34/api/</url>
+  </set>
+  <set minlat="54.915275" minlon="-1.565195" maxlat="54.947258" maxlon="-1.36232">
+    <name>Sunderland - 20120221</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/35/api/</url>
+  </set>
+  <set minlat="51.430128" minlon="-0.504796" maxlat="51.625241" maxlon="-0.281526">
+    <name>SuperLondonBorough1 - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/36/api/</url>
+  </set>
+  <set minlat="51.542623" minlon="-0.304933" maxlat="51.684693" maxlon="-0.011618">
+    <name>SuperLondonBorough2+3 - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/37/api/</url>
+  </set>
+  <set minlat="51.498151" minlon="-0.016346" maxlat="51.633308" maxlon="0.299047">
+    <name>SuperLondonBorough4 - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/38/api/</url>
+  </set>
+  <set minlat="51.324782" minlon="-0.406307" maxlat="51.482102" maxlon="-0.141699">
+    <name>SuperLondonBorough5 - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/39/api/</url>
+  </set>
+  <set minlat="51.41122" minlon="-0.15026" maxlat="51.45707" maxlon="0.033523">
+    <name>SuperLondonBorough6 - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/40/api/</url>
+  </set>
+  <set minlat="51.300949" minlon="-0.145914" maxlat="51.433614" maxlon="0.14803">
+    <name>SuperLondonBorough7 - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/41/api/</url>
+  </set>
+  <set minlat="51.416891" minlon="0.011745" maxlat="51.515881" maxlon="0.216144">
+    <name>SuperLondonBorough8 - 20120220</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/42/api/</url>
+  </set>
+  <set minlat="54.493279" minlon="-1.31239" maxlat="54.731017" maxlon="-0.793508">
+    <name>Teesside - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/43/api/</url>
+  </set>
+  <set minlat="53.590332" minlon="-1.592231" maxlat="53.725402" maxlon="-1.235727">
+    <name>Wakefield - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/44/api/</url>
+  </set>
+  <set minlat="52.554233" minlon="-2.072235" maxlat="52.661926" maxlon="-1.915902">
+    <name>Walsall - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/45/api/</url>
+  </set>
+  <set minlat="52.542617" minlon="-2.197404" maxlat="52.634329" maxlon="-2.070909">
+    <name>Wolverhampton - 20120127</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/46/api/</url>
+  </set>
+  <set minlat="51.54997" minlon="0.392732" maxlat="51.641474" maxlon="0.543087">
+    <name>Basildon - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/47/api/</url>
+  </set>
+  <set minlat="53.689774" minlon="-2.531371" maxlat="53.790452" maxlon="-2.385581">
+    <name>Blackburn - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/48/api/</url>
+  </set>
+  <set minlat="53.747281" minlon="-3.058934" maxlat="53.926572" maxlon="-2.925009">
+    <name>Blackpool - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/49/api/</url>
+  </set>
+  <set minlat="51.337252" minlon="-0.802348" maxlat="51.402861" maxlon="-0.700303">
+    <name>Bracknell - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/50/api/</url>
+  </set>
+  <set minlat="51.717835" minlon="0.630325" maxlat="51.816062" maxlon="0.707562">
+    <name>Braintree - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/51/api/</url>
+  </set>
+  <set minlat="51.573487" minlon="-0.87715" maxlat="51.988611" maxlon="-0.582498">
+    <name>Buckinghamshire - 12032012</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/52/api/</url>
+  </set>
+  <set minlat="51.521521" minlon="0.541991" maxlat="51.610015" maxlon="0.701174">
+    <name>CastlePoint - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/53/api/</url>
+  </set>
+  <set minlat="53.170316" minlon="-3.082175" maxlat="53.304304" maxlon="-2.711351">
+    <name>CheshireWest - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/54/api/</url>
+  </set>
+  <set minlat="53.015728" minlon="-2.916618" maxlat="53.171443" maxlon="-2.699506">
+    <name>Chester - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/55/api/</url>
+  </set>
+  <set minlat="51.784124" minlon="0.737557" maxlat="51.925685" maxlon="0.962856">
+    <name>Colchester - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/56/api/</url>
+  </set>
+  <set minlat="50.06273" minlon="-5.702921" maxlat="50.827203" maxlon="-4.533691">
+    <name>Cornwall - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/57/api/</url>
+  </set>
+  <set minlat="54.100127" minlon="-3.601022" maxlat="55.09527" maxlon="-2.120812">
+    <name>Cumbria - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/58/api/</url>
+  </set>
+  <set minlat="53.72392" minlon="-0.42035" maxlat="54.101425" maxlon="-0.161186">
+    <name>EastRiding - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/59/api/</url>
+  </set>
+  <set minlat="52.875268" minlon="-1.321588" maxlat="52.950583" maxlon="-1.237924">
+    <name>Erewash - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/60/api/</url>
+  </set>
+  <set minlat="51.99325" minlon="-2.783641" maxlat="52.079985" maxlon="-2.417159">
+    <name>Herefordshire - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/61/api/</url>
+  </set>
+  <set minlat="50.618969" minlon="-1.5078" maxlat="50.763353" maxlon="-1.128605">
+    <name>IsleOfWight - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/62/api/</url>
+  </set>
+  <set minlat="52.365311" minlon="-0.793493" maxlat="52.44019" maxlon="-0.665057">
+    <name>Kettering - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/63/api/</url>
+  </set>
+  <set minlat="53.965804" minlon="-2.901501" maxlat="54.106337" maxlon="-2.504526">
+    <name>Lancaster - 20120322</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/64/api/</url>
+  </set>
+  <set minlat="52.640761" minlon="-0.838035" maxlat="53.512575" maxlon="0.032603">
+    <name>Lincolnshire - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/65/api/</url>
+  </set>
+  <set minlat="52.373858" minlon="0.36688" maxlat="52.972442" maxlon="1.739489">
+    <name>Norfolk - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/66/api/</url>
+  </set>
+  <set minlat="52.07177" minlon="-1.283094" maxlat="52.447871" maxlon="-0.802152">
+    <name>Northampton - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/67/api/</url>
+  </set>
+  <set minlat="53.531172" minlon="-0.140099" maxlat="53.583785" maxlon="0.007957">
+    <name>NorthEastLincolnshire - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/68/api/</url>
+  </set>
+  <set minlat="53.545162" minlon="-0.694346" maxlat="53.656847" maxlon="-0.332514">
+    <name>NorthLincolnshire - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/69/api/</url>
+  </set>
+  <set minlat="53.657506" minlon="-2.395658" maxlat="54.491325" maxlon="-0.392336">
+    <name>NorthYorkshire - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/70/api/</url>
+  </set>
+  <set minlat="51.488218" minlon="-1.545243" maxlat="52.081901" maxlon="-0.864014">
+    <name>Oxfordshire - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/71/api/</url>
+  </set>
+  <set minlat="53.65602" minlon="-2.803709" maxlat="53.806004" maxlon="-2.526018">
+    <name>Preston - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/72/api/</url>
+  </set>
+  <set minlat="51.358247" minlon="-1.392417" maxlat="51.49768" maxlon="-0.830842">
+    <name>ReadingNewbury - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/73/api/</url>
+  </set>
+  <set minlat="53.865896" minlon="-2.455408" maxlat="54.025405" maxlon="-2.372998">
+    <name>RibbleValley - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/74/api/</url>
+  </set>
+  <set minlat="51.230724" minlon="-0.864751" maxlat="51.313907" maxlon="-0.72917">
+    <name>Rushmoor - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/75/api/</url>
+  </set>
+  <set minlat="51.398287" minlon="-0.822409" maxlat="51.550751" maxlon="-0.501688">
+    <name>SloughWindsor - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/76/api/</url>
+  </set>
+  <set minlat="51.523684" minlon="0.699339" maxlat="51.560704" maxlon="0.776859">
+    <name>Southend - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/77/api/</url>
+  </set>
+  <set minlat="51.77548" minlon="1.119176" maxlat="51.948238" maxlon="1.290766">
+    <name>Tendring - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/78/api/</url>
+  </set>
+  <set minlat="53.672074" minlon="-3.025456" maxlat="53.783442" maxlon="-2.796945">
+    <name>WestLancashire - 20120327</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/79/api/</url>
+  </set>
+  <set minlat="51.047633" minlon="-2.320002" maxlat="51.641143" maxlon="-1.705513">
+    <name>Wiltshire - 20120312</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/80/api/</url>
+  </set>
+  <set minlat="50.940424" minlon="0.83269" maxlat="51.321664" maxlon="1.404691">
+    <name>Ashford - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/81/api/</url>
+  </set>
+  <set minlat="50.986652" minlon="-1.354502" maxlat="51.299982" maxlon="-1.049083">
+    <name>Basingstoke - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/82/api/</url>
+  </set>
+  <set minlat="50.800152" minlon="-0.239247" maxlat="50.897275" maxlon="-0.014567">
+    <name>Brighton - 20120419</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/83/api/</url>
+  </set>
+  <set minlat="52.208715" minlon="-0.308721" maxlat="52.676491" maxlon="0.312222">
+    <name>Cambridgeshire - 20120430</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/84/api/</url>
+  </set>
+  <set minlat="51.238247" minlon="1.001012" maxlat="51.392646" maxlon="1.446076">
+    <name>Canterbury - 20120419</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/85/api/</url>
+  </set>
+  <set minlat="53.054523" minlon="-2.713369" maxlat="53.349835" maxlon="-2.078971">
+    <name>CheshireEast - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/86/api/</url>
+  </set>
+  <set minlat="50.763305" minlon="-0.932308" maxlat="50.966272" maxlon="-0.54238">
+    <name>Chichester - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/87/api/</url>
+  </set>
+  <set minlat="51.398562" minlon="0.213799" maxlat="51.472056" maxlon="0.44945">
+    <name>Dartford - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/88/api/</url>
+  </set>
+  <set minlat="52.742075" minlon="-2.002706" maxlat="53.496244" maxlon="-1.305285">
+    <name>Derbyshire - 20120607</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/89/api/</url>
+  </set>
+  <set minlat="50.64681" minlon="-2.183037" maxlat="50.96279" maxlon="-1.686494">
+    <name>EastDorset - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/90/api/</url>
+  </set>
+  <set minlat="51.685084" minlon="-0.170119" maxlat="51.81902" maxlon="-0.00962">
+    <name>EastHerts - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/91/api/</url>
+  </set>
+  <set minlat="51.166116" minlon="-0.285436" maxlat="51.327688" maxlon="-0.013578">
+    <name>EastSurrey - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/92/api/</url>
+  </set>
+  <set minlat="50.765483" minlon="-0.039957" maxlat="51.142656" maxlon="0.883013">
+    <name>EastSussex - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/93/api/</url>
+  </set>
+  <set minlat="50.962982" minlon="-1.052595" maxlat="51.154287" maxlon="-0.90882">
+    <name>EHants - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/94/api/</url>
+  </set>
+  <set minlat="51.218917" minlon="-0.476154" maxlat="51.413132" maxlon="-0.282353">
+    <name>Elmbridge - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/95/api/</url>
+  </set>
+  <set minlat="51.610945" minlon="-0.014657" maxlat="51.869976" maxlon="0.352357">
+    <name>EppingUttlesfordBrentwood - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/96/api/</url>
+  </set>
+  <set minlat="51.638396" minlon="0.195884" maxlat="52.025137" maxlon="0.634571">
+    <name>EssexStanstead - 20120430</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/97/api/</url>
+  </set>
+  <set minlat="51.642806" minlon="-2.436993" maxlat="52.00819" maxlon="-1.700163">
+    <name>Gloucestershire - 20120430</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/98/api/</url>
+  </set>
+  <set minlat="51.110329" minlon="-0.808009" maxlat="51.272623" maxlon="-0.437567">
+    <name>Guildford - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/99/api/</url>
+  </set>
+  <set minlat="50.861742" minlon="-0.539695" maxlat="51.168964" maxlon="-7.3e-05">
+    <name>Horsham - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/100/api/</url>
+  </set>
+  <set minlat="52.444445" minlon="-1.554648" maxlat="52.849394" maxlon="-0.608627">
+    <name>Leicestershire - 20120607</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/101/api/</url>
+  </set>
+  <set minlat="51.13875" minlon="0.210558" maxlat="51.331865" maxlon="0.566956">
+    <name>Maidstone - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/102/api/</url>
+  </set>
+  <set minlat="51.330588" minlon="0.443515" maxlat="51.445561" maxlon="0.618529">
+    <name>Medway - 20120419</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/103/api/</url>
+  </set>
+  <set minlat="50.740176" minlon="-1.792102" maxlat="51.232139" maxlon="-1.451126">
+    <name>NewForest - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/104/api/</url>
+  </set>
+  <set minlat="52.523756" minlon="-0.458389" maxlat="52.648264" maxlon="-0.294948">
+    <name>Peterborough - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/105/api/</url>
+  </set>
+  <set minlat="51.285245" minlon="-0.775071" maxlat="51.431018" maxlon="-0.409252">
+    <name>Runnymede - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/106/api/</url>
+  </set>
+  <set minlat="52.364079" minlon="-3.068614" maxlat="52.993481" maxlon="-2.295784">
+    <name>Shropshire - 20120524</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/107/api/</url>
+  </set>
+  <set minlat="52.596566" minlon="-2.472979" maxlat="53.079972" maxlon="-1.635816">
+    <name>StaffordshireA - 20120607</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/108/api/</url>
+  </set>
+  <set minlat="53.093597" minlon="-2.082383" maxlat="53.13505" maxlon="-2.010771">
+    <name>StaffordshireB - 20120427</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/109/api/</url>
+  </set>
+  <set minlat="52.436587" minlon="-2.253664" maxlat="52.594551" maxlon="-2.187337">
+    <name>StaffordshireC - 20120518</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/110/api/</url>
+  </set>
+  <set minlat="51.706044" minlon="-0.588563" maxlat="51.841369" maxlon="-0.167882">
+    <name>StAlbans - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/111/api/</url>
+  </set>
+  <set minlat="51.874249" minlon="-0.23502" maxlat="52.06039" maxlon="-0.007233">
+    <name>Stevenage - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/112/api/</url>
+  </set>
+  <set minlat="51.962201" minlon="0.385866" maxlat="52.507066" maxlon="1.762585">
+    <name>Suffolk - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/113/api/</url>
+  </set>
+  <set minlat="51.306289" minlon="0.640029" maxlat="51.442633" maxlon="0.91975">
+    <name>Swale - 20120419</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/114/api/</url>
+  </set>
+  <set minlat="51.468941" minlon="0.228164" maxlat="51.521961" maxlon="0.452639">
+    <name>Thurrock - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/115/api/</url>
+  </set>
+  <set minlat="52.121983" minlon="-1.88414" maxlat="52.559212" maxlon="-1.272669">
+    <name>Warwickshire - 20120427</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/116/api/</url>
+  </set>
+  <set minlat="51.624431" minlon="-0.519981" maxlat="51.706259" maxlon="-0.193598">
+    <name>Watford - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/117/api/</url>
+  </set>
+  <set minlat="52.282086" minlon="-0.737539" maxlat="52.501604" maxlon="-0.45519">
+    <name>Wellingborough - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/118/api/</url>
+  </set>
+  <set minlat="50.531573" minlon="-2.895576" maxlat="51.050249" maxlon="-2.166855">
+    <name>WesternDorset - 20120423</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/119/api/</url>
+  </set>
+  <set minlat="52.053981" minlon="-2.330603" maxlat="52.410054" maxlon="-1.884669">
+    <name>Worcestershire - 20120430</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/120/api/</url>
+  </set>
+  <set minlat="50.802373" minlon="-0.544546" maxlat="50.880555" maxlon="-0.240393">
+    <name>Worthing - 20120424</name>
+    <loader>SnapshotLoader</loader>
+    <policyfile>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/crossdomain.xml</policyfile>
+    <url>http://gravitystorm.dev.openstreetmap.org/cnxc-snapshot/projects/121/api/</url>
+  </set>
 </vectors>


### PR DESCRIPTION
This patch adds the cyclestreets snapshot-server to the default vectors.xml

It also reformats vectors.xml with `xmllint --format` to make it easier to have consistent formatting.

cc @gravitystorm
