### PR TITLE
Update imagery.xml with Bartholomew Half Inch 1897-1907

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -146,6 +146,14 @@
     <url>http://ooc.openstreetmap.org/npescotland/tiles/$z/$x/$y.jpg</url>
     <sourcetag>NPE</sourcetag>
   </set>
+  <set minlat="49.8" minlon="-9" maxlat="61.1" maxlon="1.9">
+    <name>Bartholomew Half Inch, 1897-1907 (NLS)</name>
+    <scheme>tms</scheme>
+    <url>http://geo.nls.uk/mapdata2/bartholomew/great_britain/$z/$x/$y.png</url>
+    <logo>icons/logo_nls70-nq8.png</logo>
+    <logo_url>http://geo.nls.uk/maps/</logo_url>
+    <sourcetag>Bartholomew Half Inch, 1897-1907</sourcetag>
+  </set>
   <set minlat="51.071" minlon="-0.856" maxlat="51.473" maxlon="0.062">
     <name>Surrey aerial</name>
     <url>http://gravitystorm.dev.openstreetmap.org/surrey/$z/$x/$y.png</url>


### PR DESCRIPTION
Added Bartholomew Half Inch 1897-1907 from National Library of Scotland servers. NLS have given written permission to do this. The maps are from John George Bartholomew and copyright expired in 1990 (70 years after death of author).

OS Town Plans to follow.
