### PR TITLE
Add OSM GPS Tile Layer as a background option

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -24,6 +24,11 @@
     <sourcetag>MapQuest Open Aerial</sourcetag>
   </set>
   <set>
+    <name>OSM GPS Tile Layer</name>
+    <url>http://${a|b|c}.gps-tile.openstreetmap.org/lines/$z/$x/$y.png</url>
+    <sourcetag>GPS</sourcetag>
+  </set>
+  <set>
     <name>OSM - Mapnik</name>
     <url>http://${a|b|c}.tile.openstreetmap.org/$z/$x/$y.png</url>
     <sourcetag>Mapnik</sourcetag>


### PR DESCRIPTION
The GPS Tile Layer ([which looks like this](http://bl.ocks.org/ericfischer/raw/713d24985c9a4a085629/#16/52.5104/-1.8617)) produced by MapBox is REALLY useful. Not only does it give a really solid "ground truth" for tracing roads and easy alignment of other imagery, but it helps understand directions and flows too. It would be great as a standard option in Potlatch2...
