### PR TITLE
Add VicMap to imagery.xml

### DIFF
--- a/resources/imagery.xml
+++ b/resources/imagery.xml
@@ -243,4 +243,9 @@
     <url>http://${a|b|c}.aerial.openstreetmap.org.za/ngi-aerial/$z/$x/$y.jpg</url>
     <sourcetag>ngi-aerial</sourcetag>
   </set>
-</imagery>
+  <set minlat="-34" minlon="140" maxlat="-39.2" maxlon="150">
+    <name>VicMap (Australia, CC-BY)</name>
+    <url>http://whoots.mapwarper.net/tms/$z/$x/$y/WEB_MERCATOR/http://api.maps.vic.gov.au/geowebcacheWM/service/wms?VERSION=1.1.1&TILED=true</url>
+    <sourcetag>Vicmap</sourcetag>
+  </set>
+  </imagery>


### PR DESCRIPTION
The VicMap base map has been open licensed for a couple of years and is very useful for copying. Unfortunately it's only available through WMS so we have to use mapwarper.net to convert it, but this works very well in practice..