### PR TITLE
Couple of minor things for 2.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,6 +20,7 @@
   <target name="git-buildnumber" description="Store output from git-describe in ${buildnumber}" if="git.present">
     <exec outputproperty="build_number" executable="git" dir="${basedir}">
       <arg value="describe" />
+      <arg value="--tags" />
     </exec>
   </target>
 

--- a/version.as.template
+++ b/version.as.template
@@ -3,5 +3,5 @@
 // at some point in the future.
 
 public var build_number:String="@@@buildnumber@@@";
-public var version:String="2.3";
+public var version:String="2.4";
 


### PR DESCRIPTION
The 2.4 tag is not annotated so `git describe` won't pick it up without `--tags` and also the version hadn't been bumped.